### PR TITLE
Fix func GetAbsURL (#1)

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -344,19 +344,23 @@ func SortFormKeys(strs []string) {
 
 // GetAbsURL get absolute URL from request, refer: https://stackoverflow.com/questions/6899069/why-are-request-url-host-and-scheme-blank-in-the-development-server
 func GetAbsURL(req *http.Request) url.URL {
-	var result url.URL
-
 	if req.URL.IsAbs() {
 		return *req.URL
 	}
 
+	var result *url.URL
 	if domain := req.Header.Get("Origin"); domain != "" {
-		parseResult, _ := url.Parse(domain)
-		result = *parseResult
+		result, _ = url.Parse(domain)
+	} else {
+		if req.TLS == nil {
+			result, _ = url.Parse("http://" + req.Host)
+		} else {
+			result, _ = url.Parse("https://" + req.Host)
+		}
 	}
 
 	result.Parse(req.RequestURI)
-	return result
+	return *result
 }
 
 // Indirect returns last value that v points to


### PR DESCRIPTION
* resolve absolute url from host
* fixing "result" variable twice declaring

This is to fix errors like:
`2019/08/07 17:03:14 [error] 19246#19246: *14 open() "/etc/nginx/html/assets/javascripts/qor_admin_default.js" failed (2: No such file or directory), client: 78.35.22.243, server: internal.odoscope.cloud, request: "GET /assets/javascripts/qor_admin_default.js HTTP/1.1", host: "internal.odoscope.cloud", referrer: "https://internal.odoscope.cloud/anomweb/"`
Please take a look at these changes.